### PR TITLE
Remove namespace from values

### DIFF
--- a/charts/digger-backend/Chart.yaml
+++ b/charts/digger-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digger-backend/templates/backend-deployment.yaml
+++ b/charts/digger-backend/templates/backend-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "digger-backend.fullname" . }}-web
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/digger-backend/templates/backend-ingress.yaml
+++ b/charts/digger-backend/templates/backend-ingress.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "digger-backend.fullname" . }}
-  namespace: {{ .Values.namespace }}
   annotations:
   {{- range $key, $value := .Values.digger.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/digger-backend/templates/backend-service.yaml
+++ b/charts/digger-backend/templates/backend-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "digger-backend.fullname" . }}-web
-  namespace: {{ .Values.namespace }}
 spec:
   type: {{ .Values.digger.service.type }}
   ports:

--- a/charts/digger-backend/templates/digger-secret.yaml
+++ b/charts/digger-backend/templates/digger-secret.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "digger-backend.fullname" . }}-secret
-  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   HTTP_BASIC_AUTH_USERNAME: {{ .Values.digger.secret.httpBasicAuthUsername | b64enc | quote }}

--- a/charts/digger-backend/templates/postgres-secret.yaml
+++ b/charts/digger-backend/templates/postgres-secret.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "digger-backend.fullname" . }}-postgres-secret
-  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   postgres-password: {{ .Values.postgres.secret.password | b64enc | quote }}

--- a/charts/digger-backend/templates/postgres-service.yaml
+++ b/charts/digger-backend/templates/postgres-service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "digger-backend.fullname" . }}-postgres
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - port: 5432

--- a/charts/digger-backend/templates/postgres-statefulset.yaml
+++ b/charts/digger-backend/templates/postgres-statefulset.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "digger-backend.fullname" . }}-postgres
-  namespace: {{ .Values.namespace }}
 spec:
   serviceName: "{{ include "digger-backend.fullname" . }}-postgres"
   replicas: 1

--- a/charts/digger-backend/values.yaml
+++ b/charts/digger-backend/values.yaml
@@ -1,5 +1,4 @@
 # values.yaml
-namespace: digger-backend
 
 digger:
 


### PR DESCRIPTION
Helm has a --namespace argument for a reason. ;)

Using a non-standard mechanism like putting the namespace in the values file "breaks" tools like argo and flux, and confuses people who expect the helm .Release.Namespace value to be respected. This change also means future expansion is easier, since there is no need to remember to add an explicit namespace to every single resource. :)