### PR TITLE
Update to support DB Operator

### DIFF
--- a/charts/digger-backend/Chart.yaml
+++ b/charts/digger-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digger-backend/templates/backend-deployment.yaml
+++ b/charts/digger-backend/templates/backend-deployment.yaml
@@ -29,17 +29,21 @@ spec:
         - secretRef:
         {{- if not .Values.digger.secret.useExistingSecret }}
             name: {{ include "digger-backend.fullname" . }}-secret
+        {{- else if .Values.digger.postgres.existingSecretName }}
+            name: {{ .Values.digger.postgres.existingSecretName }}
         {{- else }}
             name: {{ .Values.digger.secret.existingSecretName }}       
         {{- end }}
         env:
         - name: HTTP_BASIC_AUTH
           value: "1"
+        {{- if not .Values.digger.postgres.existingSecretName }}
         - name: DATABASE_URL
         {{- if .Values.postgres.enabled }}
           value: "postgres://postgres:$(POSTGRES_PASSWORD)@{{ include "digger-backend.fullname" . }}-postgres:5432/postgres?sslmode=disable"
         {{- else }}
           value: "postgres://{{ .Values.digger.postgres.user }}:$(POSTGRES_PASSWORD)@{{ .Values.digger.postgres.host }}:{{ .Values.digger.postgres.port }}/{{ .Values.digger.postgres.database }}"
+        {{- end }}
         {{- end }}
         - name: ALLOW_DIRTY
           value: "{{ .Values.digger.postgres.allow_dirty }}"

--- a/charts/digger-backend/values.yaml
+++ b/charts/digger-backend/values.yaml
@@ -87,6 +87,12 @@ digger:
   # configure this section if you want to use an external postgres database
 
   postgres:
+    # if the DB connection string is already in a secret
+    # DB connection string should be in a key names DATABASE_URL
+    # compatible with https://github.com/kloeckner-i/db-operator, for example
+    existingSecretName: ""
+
+    # to define connection details in chart:
     user: ""
     database: ""
     host: ""


### PR DESCRIPTION
Support postgres connection information in a separate secret, facilitating functionality with something like DB Operator (or another Database manager).