### PR TITLE
Fix secret conflict

### DIFF
--- a/charts/digger-backend/Chart.yaml
+++ b/charts/digger-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digger-backend/templates/backend-deployment.yaml
+++ b/charts/digger-backend/templates/backend-deployment.yaml
@@ -29,10 +29,12 @@ spec:
         - secretRef:
         {{- if not .Values.digger.secret.useExistingSecret }}
             name: {{ include "digger-backend.fullname" . }}-secret
-        {{- else if .Values.digger.postgres.existingSecretName }}
-            name: {{ .Values.digger.postgres.existingSecretName }}
         {{- else }}
             name: {{ .Values.digger.secret.existingSecretName }}       
+        {{- end }}
+        {{- if .Values.digger.postgres.existingSecretName }}
+        - secretRef:
+            name: {{ .Values.digger.postgres.existingSecretName }}
         {{- end }}
         env:
         - name: HTTP_BASIC_AUTH


### PR DESCRIPTION
Fixes bug introduced in #7 (whoops). The DB connection string secret was added in a way which stepped on the other config secret, so either one would work separately, but they didn't work together.

Sorry about that.