### PR TITLE
base64 encode the content of `GITHUB_APP_PRIVATE_KEY_BASE64`

### DIFF
--- a/charts/digger-backend/templates/digger-secret.yaml
+++ b/charts/digger-backend/templates/digger-secret.yaml
@@ -15,6 +15,6 @@ data:
   GITHUB_APP_CLIENT_SECRET: {{ .Values.digger.secret.githubAppClientSecret | b64enc | quote }}
   GITHUB_APP_PRIVATE_KEY: {{ .Values.digger.secret.githubAppKeyFile | quote }}
   # Note we keeping the one without _BASE64 suffix for backward compatibility
-  GITHUB_APP_PRIVATE_KEY_BASE64: {{ .Values.digger.secret.githubAppKeyFile | quote }}
+  GITHUB_APP_PRIVATE_KEY_BASE64: {{ .Values.digger.secret.githubAppKeyFile | b64enc | quote }}
   GITHUB_WEBHOOK_SECRET: {{ .Values.digger.secret.githubWebhookSecret | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
`GITHUB_APP_PRIVATE_KEY_BASE64` expects to have the key base64-encoded. 

If we do not encode there people can not copy paste the `gh-app-key-file Base64 encoded` content from the GitHub App creation wizard as is and need to base64 before. 